### PR TITLE
The default parameter for this method doesn't repair metadata API cache

### DIFF
--- a/sugar_repair/sugar_repair
+++ b/sugar_repair/sugar_repair
@@ -48,7 +48,7 @@ function setup_environment() {
 
 function repair() {
     $repair = new RepairAndClear();
-    $repair->repairAndClearAll(array('clearAll'),array(translate('LBL_ALL_MODULES')), true,false);
+    $repair->repairAndClearAll(array('clearAll'),array(translate('LBL_ALL_MODULES')), true,false, '');
     //remove the js language files
     LanguageManager::removeJSLanguageFiles();
     //remove language cache files


### PR DESCRIPTION
For a CLI tool I think that is better to repair everything and by consequence clean out current metadata cache and rebuilds it for each platform and visibility